### PR TITLE
fix:fix the tail of 0.

### DIFF
--- a/fracdex.go
+++ b/fracdex.go
@@ -138,7 +138,10 @@ func midpoint(a string, b string) string {
 
 	// first digits are consecutive
 	if len(b) > 1 {
-		return b[0:1]
+		if b[0] != '0' {
+			return b[0:1]
+		}
+		return string(base62Digits[digitA]) + midpoint("", b[1:])
 	}
 
 	// `b` is empty or has length 1 (a single digit).

--- a/fracdex_test.go
+++ b/fracdex_test.go
@@ -41,6 +41,7 @@ func TestKeys(t *testing.T) {
 	test("Zz", "a01", "a0")
 	test("", "a0V", "a0")
 	test("", "b999", "b99")
+	test("aV", "aV0V", "aV0G")
 	test(
 		"",
 		"A00000000000000000000000000",
@@ -53,6 +54,7 @@ func TestKeys(t *testing.T) {
 	test("a00", "a1", "invalid order key: a00")
 	test("0", "1", "invalid order key head: 0")
 	test("a1", "a0", "a1 >= a0")
+
 }
 
 func TestNKeys(t *testing.T) {


### PR DESCRIPTION
Fix the tail of 0.
When a is "aV" and b is "aV0V", the mid return is aV0, which is not expected.
The result should be aV0G